### PR TITLE
po: Disable window.ui from POTFILES

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -1,7 +1,7 @@
 data/io.github.seadve.Kooha.desktop.in
 data/io.github.seadve.Kooha.appdata.xml.in
 data/io.github.seadve.Kooha.gschema.xml
-src/window.ui
+#src/window.ui
 src/main.py
 src/window.py
 


### PR DESCRIPTION
 `src/window.ui` doesn't exist in the source tree, and listing it in `po/POTFILES` blocks from generating/updating template for translation files.

```
$ meson . build
....
$ ninja -C build kooha-pot                           
ninja: Entering directory `build'
[0/1] Running external command kooha-pot (wrapped by meson to set env)
xgettext: cannot read /home/rafael/build/kooha/src/Kooha/src/window.ui: failed to load external entity "/home/rafael/build/kooha/src/Kooha/src/window.ui"

xgettext: cannot read /home/rafael/build/kooha/src/Kooha/src/window.ui: failed to load external entity "/home/rafael/build/kooha/src/Kooha/src/window.ui"

xgettext: cannot read /home/rafael/build/kooha/src/Kooha/src/window.ui: failed to load external entity "/home/rafael/build/kooha/src/Kooha/src/window.ui"

xgettext: cannot read /home/rafael/build/kooha/src/Kooha/src/window.ui: failed to load external entity "/home/rafael/build/kooha/src/Kooha/src/window.ui"

xgettext: cannot read /home/rafael/build/kooha/src/Kooha/src/window.ui: failed to load external entity "/home/rafael/build/kooha/src/Kooha/src/window.ui"

xgettext: warning: file 'src/window.ui' extension 'ui' is unknown; will try C
xgettext: error while opening "src/window.ui" for reading: No such file or directory
while executing ['/usr/bin/meson', '--internal', 'gettext', 'pot', '--pkgname=kooha', '--extra-args=--keyword=g_dpgettext2:2c,3@@--flag=N_:1:pass-c-format@@--flag=g_printf:1:c-format@@--keyword=NC_:1c,2@@--keyword=N_@@--flag=g_set_error:4:c-format@@--flag=g_sprintf:2:c-format@@--flag=g_markup_printf_escaped:1:c-format@@--add-comments@@--flag=g_print:1:c-format@@--flag=g_printerr:1:c-format@@--keyword=g_dngettext:2,3@@--keyword=_@@--flag=g_snprintf:3:c-format@@--flag=g_string_printf:2:c-format@@--flag=g_fprintf:2:c-format@@--flag=g_strdup_printf:1:c-format@@--flag=g_string_append_printf:2:c-format@@--flag=g_log:3:c-format@@--flag=C_:2:pass-c-format@@--flag=NC_:2:pass-c-format@@--keyword=C_:1c,2@@--flag=g_dngettext:2:pass-c-format@@--from-code=UTF-8@@--flag=g_error_new:3:c-format@@--keyword=g_dcgettext:2']
FAILED: meson-kooha-pot 
/usr/bin/meson --internal exe --unpickle /home/rafael/build/kooha/src/Kooha/build/meson-private/meson_exe_meson_2d538506d1d1ff70e45e655f50f8ee0198d49a24.dat
ninja: build stopped: subcommand failed.
```