### PR TITLE
Avoid unnecessary calls to translation file when fetching translation

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -24,7 +24,7 @@ jobs:
           sudo apt -y install flake8
       - name: Lint with flake8
         run: |
-          flake8 --ignore E402,W503 --max-complexity=10 --max-line-length=110 --show-source --statistics src/
+          flake8 --builtins=_ --ignore E402,W503 --max-complexity=10 --max-line-length=110 --show-source --statistics src/
 
   mypy:
     name: "Static Type Checker"

--- a/src/kooha.in
+++ b/src/kooha.in
@@ -32,8 +32,7 @@ signal.signal(signal.SIGINT, signal.SIG_DFL)
 
 locale.bindtextdomain('kooha', localedir)
 locale.textdomain('kooha')
-gettext.bindtextdomain('kooha', localedir)
-gettext.textdomain('kooha')
+gettext.install('kooha', localedir)
 
 if __name__ == '__main__':
     import gi

--- a/src/main.py
+++ b/src/main.py
@@ -16,7 +16,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
-from gettext import gettext as _
 
 import gi
 gi.require_version('Gst', '1.0')

--- a/src/window.py
+++ b/src/window.py
@@ -16,7 +16,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-from gettext import gettext as _
 from threading import Thread
 from time import localtime, strftime
 


### PR DESCRIPTION
By using gettext.install, we access the .mo file once and store the translation data for later access, whereas the previous approach opens the .mo file each time a single translated string is fetched.

See: https://github.com/python/cpython/blob/b38601d49675d90e1ee6faa47f7adaeca992d02d/Lib/gettext.py#L666
https://github.com/python/cpython/blob/b38601d49675d90e1ee6faa47f7adaeca992d02d/Lib/gettext.py#L583

This change probably doesn't affect performance in Kooha, but provided a performance boost for a larger project I work on. It also makes it easy to access the _() function everywhere.