### PR TITLE
Don't crash if XDG_CURRENT_DESKTOP is not set

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -53,9 +53,10 @@ class KoohaWindow(Handy.ApplicationWindow):
         self.video_recorder = VideoRecorder()
 
         desktop_environment = GLib.getenv('XDG_CURRENT_DESKTOP')
-        if "GNOME" not in desktop_environment:
+        if desktop_environment is None or "GNOME" not in desktop_environment:
             self.start_record_button.set_sensitive(False)
-            self.start_record_button.set_label(f"{desktop_environment} is not yet supported")
+            self.start_record_button.set_label(
+                unsupported_desktop_ennvironment_message(desktop_environment))
 
     @Gtk.Template.Callback()
     def on_start_record_button_clicked(self, widget):
@@ -148,3 +149,10 @@ class KoohaWindow(Handy.ApplicationWindow):
         self.main_stack.set_visible_child(self.main_screen_box)
 
         self.delay_timer.cancel()
+
+
+def unsupported_desktop_ennvironment_message(desktop_environment):
+    if desktop_environment is not None:
+        return f"{desktop_environment} is not yet supported"
+    else:
+        return "Desktop environment is not yet supported"

--- a/src/window.py
+++ b/src/window.py
@@ -55,7 +55,7 @@ class KoohaWindow(Handy.ApplicationWindow):
         desktop_environment = GLib.getenv('XDG_CURRENT_DESKTOP')
         if not desktop_environment or "GNOME" not in desktop_environment:
             self.start_record_button.set_sensitive(False)
-            self.start_record_button.set_label(get_environment_message(desktop_environment))
+            self.start_record_button.set_label(self.get_environment_message(desktop_environment))
 
     @Gtk.Template.Callback()
     def on_start_record_button_clicked(self, widget):
@@ -129,8 +129,8 @@ class KoohaWindow(Handy.ApplicationWindow):
         notification.set_body(f"{notification_body} {self.get_saving_location()[1]}")
         notification.set_default_action("app.show-saving-location")
         self.get_application().send_notification(None, notification)
-        
-    def get_environment_message(desktop_environment):
+
+    def get_environment_message(self, desktop_environment):
         if not desktop_environment:
             desktop_environment = "WM"
         return f"{desktop_environment} is not yet supported"

--- a/src/window.py
+++ b/src/window.py
@@ -53,10 +53,9 @@ class KoohaWindow(Handy.ApplicationWindow):
         self.video_recorder = VideoRecorder()
 
         desktop_environment = GLib.getenv('XDG_CURRENT_DESKTOP')
-        if desktop_environment is None or "GNOME" not in desktop_environment:
+        if not desktop_environment or "GNOME" not in desktop_environment:
             self.start_record_button.set_sensitive(False)
-            self.start_record_button.set_label(
-                unsupported_desktop_ennvironment_message(desktop_environment))
+            self.start_record_button.set_label(get_environment_message(desktop_environment))
 
     @Gtk.Template.Callback()
     def on_start_record_button_clicked(self, widget):
@@ -130,6 +129,11 @@ class KoohaWindow(Handy.ApplicationWindow):
         notification.set_body(f"{notification_body} {self.get_saving_location()[1]}")
         notification.set_default_action("app.show-saving-location")
         self.get_application().send_notification(None, notification)
+        
+    def get_environment_message(desktop_environment):
+        if not desktop_environment:
+            desktop_environment = "WM"
+        return f"{desktop_environment} is not yet supported"
 
     @Gtk.Template.Callback()
     def on_stop_record_button_clicked(self, widget):
@@ -149,10 +153,3 @@ class KoohaWindow(Handy.ApplicationWindow):
         self.main_stack.set_visible_child(self.main_screen_box)
 
         self.delay_timer.cancel()
-
-
-def unsupported_desktop_ennvironment_message(desktop_environment):
-    if desktop_environment is not None:
-        return f"{desktop_environment} is not yet supported"
-    else:
-        return "Desktop environment is not yet supported"


### PR DESCRIPTION
XDG_CURRENT_DESKTOP might not always be set, for example if people use
tiling window managers like sway.

Signed-off-by: Felix Weilbach <felix.weilbach@t-online.de>