### PR TITLE
build: fix a warning on non-GNU distributions

### DIFF
--- a/build-aux/cargo.sh
+++ b/build-aux/cargo.sh
@@ -5,7 +5,7 @@ export MESON_SOURCE_ROOT="$2"
 export CARGO_TARGET_DIR="$MESON_BUILD_ROOT"/target
 export CARGO_HOME="$MESON_BUILD_ROOT"/cargo-home
 
-if [[ $4 = "Devel" ]]
+if [ "$4" = "Devel" ]
 then
     echo "DEBUG MODE"
     cargo build --manifest-path \


### PR DESCRIPTION
Found on FreeBSD where `/bin/sh` descends from [Almquist shell](https://en.wikipedia.org/wiki/Almquist_shell).

`[[` is supported by Bash, Zsh, [oksh](https://www.mankier.com/1/oksh) but not by [FreeBSD sh](https://man.freebsd.org/sh/1), [NetBSD sh](https://man.netbsd.org/sh.1), [dash](https://www.man7.org/linux/man-pages/man1/dash.1.html), [mrsh](https://github.com/emersion/mrsh).

```
dash$ [[ foo = bar ]]
dash: 1: [[: not found

mrsh$ [[ foo = bar ]]
mrsh:0:0: syntax error: keyword is reserved and causes unspecified results: [[
```
