### PR TITLE
fix(pipeline): add latency on audiomixer

### DIFF
--- a/build-aux/io.github.seadve.Kooha.Devel.json
+++ b/build-aux/io.github.seadve.Kooha.Devel.json
@@ -18,8 +18,7 @@
         "--env=RUST_LIB_BACKTRACE=0",
         "--env=RUST_LOG=kooha=debug",
         "--env=G_MESSAGES_DEBUG=none",
-        "--env=KOOHA_EXPERIMENTAL=1",
-        "--env=GST_DEBUG=3"
+        "--env=KOOHA_EXPERIMENTAL=1"
     ],
     "build-options": {
         "append-path": "/usr/lib/sdk/llvm16/bin:/usr/lib/sdk/rust-stable/bin",

--- a/data/io.github.seadve.Kooha.metainfo.xml.in.in
+++ b/data/io.github.seadve.Kooha.metainfo.xml.in.in
@@ -48,6 +48,7 @@
           <li>Notification actions now work even when the application is closed</li>
           <li>Progress is now shown when flushing the recording</li>
           <li>It is now much easier to pick from frame rate options</li>
+          <li>Actually fixed audio from stuttering and being cut on long recordings</li>
           <li>Fixed focus on area selector</li>
           <li>Fixed too small area selector window on HiDPI monitors</li>
           <li>Improved recording performance</li>

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -331,7 +331,9 @@ pub fn make_pipewiresrc_bin(
 fn make_pulsesrc_bin<'a>(device_names: impl IntoIterator<Item = &'a str>) -> Result<gst::Bin> {
     let bin = gst::Bin::builder().name("kooha-pulsesrc-bin").build();
 
-    let audiomixer = gst::ElementFactory::make("audiomixer").build()?;
+    let audiomixer = gst::ElementFactory::make("audiomixer")
+        .property("latency", gst::ClockTime::from_seconds(1))
+        .build()?;
     bin.add(&audiomixer)?;
 
     let src_pad = audiomixer.static_pad("src").unwrap();

--- a/src/recording.rs
+++ b/src/recording.rs
@@ -592,6 +592,10 @@ impl Recording {
                 tracing::debug!("Received info message on bus: {:?}", i);
                 glib::ControlFlow::Continue
             }
+            MessageView::Qos(q) => {
+                tracing::warn!("Received qos message on bus: {:?}", q);
+                glib::ControlFlow::Continue
+            }
             other => {
                 tracing::trace!("Received other message on bus: {:?}", other);
                 glib::ControlFlow::Continue


### PR DESCRIPTION
Also remove GST_DEBUG=3 by default as it is too verbose and not that helpful.

This commit also upgrades QoS messages to warn log level.

 Fixes #218