### PR TITLE
appdata: `translate=no` properties

### DIFF
--- a/data/io.github.seadve.Kooha.metainfo.xml.in.in
+++ b/data/io.github.seadve.Kooha.metainfo.xml.in.in
@@ -38,7 +38,7 @@
   <content_rating type="oars-1.1"/>
   <releases>
     <release version="2.3.0" date="2024-03-21">
-      <description translatable="no">
+      <description translate="no">
         <p>This release contains new features and fixes:</p>
         <ul>
           <li>Area selector window is now resizable</li>
@@ -62,7 +62,7 @@
       </description>
     </release>
     <release version="2.2.4" date="2023-09-23">
-      <description translatable="no">
+      <description translate="no">
         <p>This release contains minor fixes:</p>
         <ul>
           <li>Added window close shortcut</li>
@@ -72,7 +72,7 @@
       </description>
     </release>
     <release version="2.2.3" date="2022-12-25">
-      <description translatable="no">
+      <description translate="no">
         <p>This release contains minor fixes:</p>
         <ul>
           <li>Fixed indefinite flushing time on certain distros</li>
@@ -82,7 +82,7 @@
       </description>
     </release>
     <release version="2.2.2" date="2022-10-02">
-      <description translatable="no">
+      <description translate="no">
         <p>This release contains minor fixes:</p>
         <ul>
           <li>Fixed error dialog showing when show uri is simply cancelled</li>
@@ -92,7 +92,7 @@
       </description>
     </release>
     <release version="2.2.1" date="2022-10-01">
-      <description translatable="no">
+      <description translate="no">
         <p>This release contains minor fixes:</p>
         <ul>
           <li>Only show None profile when it is active</li>
@@ -102,7 +102,7 @@
       </description>
     </release>
     <release version="2.2.0" date="2022-09-29">
-      <description translatable="no">
+      <description translate="no">
         <p>This release contains new features and fixes:</p>
         <ul>
           <li>New area selection UI</li>
@@ -119,7 +119,7 @@
       </description>
     </release>
     <release version="2.1.1" date="2022-08-21">
-      <description translatable="no">
+      <description translate="no">
         <p>This release contains fixes:</p>
         <ul>
           <li>Improved tooltip text on settings toggle buttons</li>
@@ -129,7 +129,7 @@
       </description>
     </release>
     <release version="2.1.0" date="2022-08-19">
-      <description translatable="no">
+      <description translate="no">
         <p>This release contains new features and fixes:</p>
         <ul>
           <li>Remember previously selected video sources</li>
@@ -149,7 +149,7 @@
       </description>
     </release>
     <release version="2.0.1" date="2021-10-20">
-      <description translatable="no">
+      <description translate="no">
         <p>This is a minor release:</p>
         <ul>
           <li>GIF recordings now loops infinitely</li>
@@ -170,7 +170,7 @@
       </description>
     </release>
     <release version="2.0.0" date="2021-09-23">
-      <description translatable="no">
+      <description translate="no">
         <p>This is a big release containing a lot of fixes and new features!</p>
         <ul>
           <li>Added MP4 and GIF formats</li>
@@ -190,7 +190,7 @@
       </description>
     </release>
     <release version="1.2.1" date="2021-05-23">
-      <description translatable="no">
+      <description translate="no">
         <p>This release contains small fixes and improvements:</p>
         <ul>
           <li>Focus start record button on startup</li>
@@ -208,7 +208,7 @@
       </description>
     </release>
     <release version="1.2.0" date="2021-05-17">
-      <description translatable="no">
+      <description translate="no">
         <p>This release brings the new GTK4 and an important fix for GNOME 40.</p>
         <ul>
           <li>Recording performance improvements</li>
@@ -226,7 +226,7 @@
       </description>
     </release>
     <release version="1.1.3" date="2021-05-04">
-      <description translatable="no">
+      <description translate="no">
         <p>New fixes and translations update coming this release:</p>
         <ul>
           <li>More responsive shortcuts</li>
@@ -239,7 +239,7 @@
       </description>
     </release>
     <release version="1.1.2" date="2021-04-25">
-      <description translatable="no">
+      <description translate="no">
         <p>This is a minor release composing of fixes and improvements:</p>
         <ul>
           <li>Minor performance optimizations</li>
@@ -257,7 +257,7 @@
       </description>
     </release>
     <release version="1.1.1" date="2021-04-09">
-      <description translatable="no">
+      <description translate="no">
         <p>This release is composing of minor changes:</p>
         <ul>
           <li>Minor UI improvements</li>
@@ -270,7 +270,7 @@
       </description>
     </release>
     <release version="1.1.0" date="2021-03-25">
-      <description translatable="no">
+      <description translate="no">
         <p>This update brings new features and few bug fixes:</p>
         <ul>
           <li>Added a processing view to avoid recording corruption</li>
@@ -281,7 +281,7 @@
       </description>
     </release>
     <release version="1.0.5" date="2021-03-24">
-      <description translatable="no">
+      <description translate="no">
         <p>This is a small update composing of bug fixes:</p>
         <ul>
           <li>Fix audio recording in other locales</li>
@@ -292,7 +292,7 @@
       </description>
     </release>
     <release version="1.0.4" date="2021-03-23">
-      <description translatable="no">
+      <description translate="no">
         <p>This release brings a couple of improvements:</p>
         <ul>
           <li>New! Ability to select audio devices through GNOME Settings</li>
@@ -306,7 +306,7 @@
       </description>
     </release>
     <release version="1.0.3" date="2021-03-17">
-      <description translatable="no">
+      <description translate="no">
         <p>A couple of bug fixes here and improvements there:</p>
         <ul>
           <li>Minor performance improvements</li>
@@ -318,7 +318,7 @@
       </description>
     </release>
     <release version="1.0.2" date="2021-03-15">
-      <description translatable="no">
+      <description translate="no">
         <p>This release brings a couple of small changes:</p>
         <ul>
           <li>set WebM as default format</li>
@@ -328,7 +328,7 @@
       </description>
     </release>
     <release version="1.0.1" date="2021-03-14">
-      <description translatable="no">
+      <description translate="no">
         <p>Version 1.0.1 brings fixes to a couple of bugs:</p>
         <ul>
           <li>Catch the error when the path of the directory no longer exists</li>
@@ -340,7 +340,7 @@
       </description>
     </release>
     <release version="1.0.0" date="2021-03-13">
-      <description translatable="no">
+      <description translate="no">
         <p>This is the 1.0 release of Kooha. The features of this release include the following:</p>
         <ul>
           <li>Record your screen and also audio from your microphone or desktop</li>
@@ -354,7 +354,7 @@
       </description>
     </release>
     <release version="0.1.0" date="2021-03-06">
-      <description translatable="no">
+      <description translate="no">
         <p>Initial release.</p>
       </description>
     </release>
@@ -365,9 +365,9 @@
     <kudo>Notifications</kudo>
   </kudos>
   <!-- developer_name tag deprecated with Appstream 1.0 -->
-  <developer_name translatable="no">Dave Patrick Caberto</developer_name>
+  <developer_name translate="no">Dave Patrick Caberto</developer_name>
   <developer id="io.github.seadve">
-    <name translatable="no">Dave Patrick Caberto</name>
+    <name translate="no">Dave Patrick Caberto</name>
   </developer>
   <update_contact>davecruz48@gmail.com</update_contact>
   <translation type="gettext">@gettext-package@</translation>


### PR DESCRIPTION
It appears that the appstream project no longer supports `translatable=no` properties, and gettext extract the `translatable=no` marked strings as translatable.

I opened an issue to inform about the situation, but `translatable=no` properties are not accepted by developers. You can find the issue here: `https://github.com/ximion/appstream/issues/623`

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html