### PR TITLE
create stored_saving_location if not existing, fallback to saving_location on error

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -58,23 +58,11 @@ impl Settings {
             glib::user_special_dir(glib::UserDirectory::Videos).unwrap_or_else(glib::home_dir);
 
         if !stored_saving_location.as_os_str().is_empty() {
-            return self.create_saving_location(stored_saving_location);
+            return ensure_location(stored_saving_location);
         }
 
         let kooha_saving_location = saving_location.join("Kooha");
-        self.create_saving_location(kooha_saving_location)
-    }
-
-    pub fn create_saving_location(&self, saving_location: PathBuf) -> PathBuf {
-        if let Err(err) = fs::create_dir_all(&saving_location) {
-            tracing::warn!(
-                "Failed to create dir at `{}`: {:?}",
-                saving_location.display(),
-                err
-            );
-            return glib::user_special_dir(glib::UserDirectory::Videos).unwrap_or_else(glib::home_dir);
-        }
-        saving_location
+        ensure_location(kooha_saving_location)
     }
 
     pub fn connect_saving_location_changed(
@@ -150,6 +138,18 @@ impl Settings {
     pub fn reset_profile(&self) {
         self.0.reset("profile-id");
     }
+}
+
+fn ensure_location(saving_location: PathBuf) -> PathBuf {
+    if let Err(err) = fs::create_dir_all(&saving_location) {
+        tracing::warn!(
+            "Failed to create dir at `{}`: {:?}",
+            saving_location.display(),
+            err
+        );
+        return glib::user_special_dir(glib::UserDirectory::Videos).unwrap_or_else(glib::home_dir);
+    }
+    saving_location
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Currently, the default directory `Kooha` gets created, if it's not existing.

However if a different directory is being set via dbus-option e.g `saving-location=b'/home/{{ USERNAME }}/Screencasts'` in corporate organizations via config-management, the directory doesn't get created automatically, instead it fails in an error.

This PR fixes this issue, by moving:
```rust
        let saving_location =
            glib::user_special_dir(glib::UserDirectory::Videos).unwrap_or_else(glib::home_dir);
```
further up and expanding `!stored_saving_location.as.os.str().is_empty()` with.
```rust
            if let Err(err) = fs::create_dir_all(&stored_saving_location) {
                tracing::warn!(
                    "Failed to create dir at `{}`: {:?}",
                    stored_saving_location.display(),
                    err
                );
                return saving_location;
            }
```
where a fallback to `saving_location` is set, in case it fails to create the directory set via `saving-location` option.

I've tested it on an Arch Linux machine by building it via a modified PKGBUILD of the [official PKGBUILD](https://gitlab.archlinux.org/archlinux/packaging/packages/kooha/-/blob/main/PKGBUILD) and it worked flawlessly in my case.