### PR TITLE
Add x11/wayland as cargo/meson features/options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,18 @@ lto = true
 debug = 0
 strip = "debuginfo"
 
+[features]
+default = ["wayland", "x11"]
+wayland = ["gdk-wayland", "gst-plugin-gtk4/wayland"]
+x11 = ["gdk-x11", "gst-plugin-gtk4/x11egl", "gst-plugin-gtk4/x11glx"]
+
 [dependencies]
 adw = { package = "libadwaita", version = "0.7", features = ["v1_6"] }
 anyhow = "1.0.59"
 futures-channel = "0.3.19"
 futures-util = { version = "0.3", default-features = false }
-gdk-wayland = { package = "gdk4-wayland", version = "0.9" }
-gdk-x11 = { package = "gdk4-x11", version = "0.9" }
+gdk-wayland = { package = "gdk4-wayland", version = "0.9", optional = true }
+gdk-x11 = { package = "gdk4-x11", version = "0.9", optional = true }
 gettext-rs = { version = "0.7.0", features = ["gettext-system"] }
 gsettings-macro = "0.2"
 gst = { package = "gstreamer", version = "0.23", features = ["v1_20"] }
@@ -28,9 +33,6 @@ gst-plugin-gif = "0.13"
 gst-plugin-gtk4 = { version = "0.13", features = [
     "dmabuf",
     "gtk_v4_14",
-    "wayland",
-    "x11egl",
-    "x11glx",
 ] }
 gtk = { package = "gtk4", version = "0.9", features = ["gnome_46"] }
 once_cell = "1.19.0"

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -8,3 +8,5 @@ option(
   value: 'default',
   description: 'The build profile for Kooha. One of "default" or "development".'
 )
+option('wayland', type : 'boolean', value : true, description: 'Wayland support.')
+option('x11', type : 'boolean', value : true, description: 'X11 support.')

--- a/src/meson.build
+++ b/src/meson.build
@@ -30,6 +30,15 @@ else
   message('Building in debug mode')
 endif
 
+cargo_options += [ '--no-default-features' ]
+if get_option('x11')
+  cargo_options += [ '--features', 'x11' ]
+endif
+
+if get_option('wayland')
+  cargo_options += [ '--features', 'wayland' ]
+endif
+
 cargo_env = [ 'CARGO_HOME=' + meson.project_build_root() / 'cargo-home' ]
 
 cargo_build = custom_target(

--- a/src/screencast_portal/window_identifier.rs
+++ b/src/screencast_portal/window_identifier.rs
@@ -1,35 +1,32 @@
 // Based on ashpd (MIT)
 // Source: https://github.com/bilelmoussaoui/ashpd/blob/49aca6ff0f20c68fc2ddb09763ed9937b002ded6/src/window_identifier/gtk4.rs
 
-use futures_channel::oneshot;
-use gtk::{
-    glib::{self, WeakRef},
-    prelude::*,
-};
+#[cfg(feature = "x11")]
+mod x11;
 
-use std::{cell::RefCell, fmt};
+#[cfg(feature = "wayland")]
+mod wayland;
 
-const WINDOW_HANDLE_KEY: &str = "kooha-wayland-window-handle";
+use gtk::{glib, prelude::*};
 
-type WindowHandleData = (Option<String>, u8);
+use std::fmt;
 
 #[derive(Debug)]
 pub enum WindowIdentifier {
-    Wayland {
-        top_level: WeakRef<gdk_wayland::WaylandToplevel>,
-        handle: Option<String>,
-    },
-    X11(gdk_x11::XWindow),
+    #[cfg(feature = "wayland")]
+    Wayland(wayland::WaylandIdentifier),
+    #[cfg(feature = "x11")]
+    X11(x11::X11Identifier),
     None,
 }
 
 impl fmt::Display for WindowIdentifier {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            WindowIdentifier::Wayland { handle, .. } => {
-                write!(f, "wayland:{}", handle.as_deref().unwrap_or_default())
-            }
-            WindowIdentifier::X11(xid) => write!(f, "x11:{:#x}", xid),
+            #[cfg(feature = "wayland")]
+            WindowIdentifier::Wayland(identifier) => identifier.fmt(f),
+            #[cfg(feature = "x11")]
+            WindowIdentifier::X11(identifier) => identifier.fmt(f),
             WindowIdentifier::None => f.write_str(""),
         }
     }
@@ -47,81 +44,30 @@ impl WindowIdentifier {
             return Self::None;
         };
 
-        if let Some(top_level) = surface.downcast_ref::<gdk_wayland::WaylandToplevel>() {
-            let handle = unsafe {
-                if let Some(mut handle) = top_level.data::<WindowHandleData>(WINDOW_HANDLE_KEY) {
-                    let (handle, ref_count) = handle.as_mut();
-                    *ref_count += 1;
-                    handle.clone()
-                } else {
-                    let (tx, rx) = oneshot::channel();
-                    let tx = RefCell::new(Some(tx));
-
-                    let result = top_level.export_handle(move |_, handle| {
-                        let tx = tx.take().expect("callback called twice");
-
-                        match handle {
-                            Ok(handle) => {
-                                let _ = tx.send(Some(handle.to_string()));
-                            }
-                            Err(err) => {
-                                tracing::warn!("Failed to export handle: {:?}", err);
-                                let _ = tx.send(None);
-                            }
-                        }
-                    });
-
-                    if !result {
-                        return Self::None;
-                    }
-
-                    let handle = rx.await.unwrap();
-                    top_level.set_data::<WindowHandleData>(WINDOW_HANDLE_KEY, (handle.clone(), 1));
-                    handle
-                }
-            };
-
-            Self::Wayland {
-                top_level: top_level.downgrade(),
-                handle,
-            }
-        } else if let Some(surface) = surface.downcast_ref::<gdk_x11::X11Surface>() {
-            Self::X11(surface.xid())
-        } else {
-            tracing::warn!(
-                "Unhandled surface backend type: {:?}",
-                surface.display().backend()
-            );
-            Self::None
+        #[cfg(feature = "wayland")]
+        if let Some(identifier) = wayland::try_downcast(&surface).await {
+            return identifier;
         }
+
+        #[cfg(feature = "x11")]
+        if let Some(identifier) = x11::try_downcast(&surface) {
+            return identifier;
+        }
+
+        tracing::warn!(
+            "Unhandled surface backend type: {:?}",
+            surface.display().backend()
+        );
+
+        Self::None
     }
 }
 
+#[cfg(feature = "wayland")]
 impl Drop for WindowIdentifier {
     fn drop(&mut self) {
-        if let WindowIdentifier::Wayland { top_level, handle } = self {
-            if handle.is_none() {
-                return;
-            }
-
-            if let Some(top_level) = top_level.upgrade() {
-                unsafe {
-                    let (handle, ref_count) = top_level
-                        .data::<WindowHandleData>(WINDOW_HANDLE_KEY)
-                        .unwrap()
-                        .as_mut();
-
-                    if *ref_count > 1 {
-                        *ref_count -= 1;
-                        return;
-                    }
-
-                    top_level.unexport_handle();
-                    tracing::trace!("Unexported handle: {:?}", handle);
-
-                    let _ = top_level.steal_data::<WindowHandleData>(WINDOW_HANDLE_KEY);
-                }
-            }
+        if let WindowIdentifier::Wayland(identifier) = self {
+            identifier.drop();
         }
     }
 }

--- a/src/screencast_portal/window_identifier/wayland.rs
+++ b/src/screencast_portal/window_identifier/wayland.rs
@@ -1,0 +1,90 @@
+use futures_channel::oneshot;
+use gtk::{gdk::Surface, glib::WeakRef, prelude::*};
+
+use std::{cell::RefCell, fmt};
+
+const WINDOW_HANDLE_KEY: &str = "kooha-wayland-window-handle";
+
+type WindowHandleData = (Option<String>, u8);
+
+#[derive(Debug)]
+pub struct WaylandIdentifier {
+    top_level: WeakRef<gdk_wayland::WaylandToplevel>,
+    handle: Option<String>,
+}
+
+impl fmt::Display for WaylandIdentifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "wayland:{}", self.handle.as_deref().unwrap_or_default())
+    }
+}
+
+impl WaylandIdentifier {
+    pub fn drop(&mut self) {
+        if self.handle.is_none() {
+            return;
+        }
+
+        if let Some(top_level) = self.top_level.upgrade() {
+            unsafe {
+                let (handle, ref_count) = top_level
+                    .data::<WindowHandleData>(WINDOW_HANDLE_KEY)
+                    .unwrap()
+                    .as_mut();
+
+                if *ref_count > 1 {
+                    *ref_count -= 1;
+                    return;
+                }
+
+                top_level.unexport_handle();
+                tracing::trace!("Unexported handle: {:?}", handle);
+
+                let _ = top_level.steal_data::<WindowHandleData>(WINDOW_HANDLE_KEY);
+            }
+        }
+    }
+}
+
+pub async fn try_downcast(surface: &Surface) -> Option<super::WindowIdentifier> {
+    if let Some(top_level) = surface.downcast_ref::<gdk_wayland::WaylandToplevel>() {
+        let handle = unsafe {
+            if let Some(mut handle) = top_level.data::<WindowHandleData>(WINDOW_HANDLE_KEY) {
+                let (handle, ref_count) = handle.as_mut();
+                *ref_count += 1;
+                handle.clone()
+            } else {
+                let (tx, rx) = oneshot::channel();
+                let tx = RefCell::new(Some(tx));
+
+                let result = top_level.export_handle(move |_, handle| {
+                    let tx = tx.take().expect("callback called twice");
+
+                    match handle {
+                        Ok(handle) => {
+                            let _ = tx.send(Some(handle.to_string()));
+                        }
+                        Err(err) => {
+                            tracing::warn!("Failed to export handle: {:?}", err);
+                            let _ = tx.send(None);
+                        }
+                    }
+                });
+
+                if !result {
+                    return None;
+                }
+
+                let handle = rx.await.unwrap();
+                top_level.set_data::<WindowHandleData>(WINDOW_HANDLE_KEY, (handle.clone(), 1));
+                handle
+            }
+        };
+
+        return Some(super::WindowIdentifier::Wayland(WaylandIdentifier {
+            top_level: top_level.downgrade(),
+            handle,
+        }));
+    }
+    None
+}

--- a/src/screencast_portal/window_identifier/x11.rs
+++ b/src/screencast_portal/window_identifier/x11.rs
@@ -1,0 +1,20 @@
+use gtk::{gdk::Surface, prelude::*};
+
+use std::fmt;
+
+#[derive(Debug)]
+pub struct X11Identifier(pub gdk_x11::XWindow);
+
+impl fmt::Display for X11Identifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "x11:{:#x}", self.0)
+    }
+}
+
+pub fn try_downcast(surface: &Surface) -> Option<super::WindowIdentifier> {
+    if let Some(surface) = surface.downcast_ref::<gdk_x11::X11Surface>() {
+        Some(super::WindowIdentifier::X11(X11Identifier(surface.xid())))
+    } else {
+        None
+    }
+}


### PR DESCRIPTION
Hi,

I'm using Gentoo and noticed that the ebuild on GURU was outdated and looking for a new maintainer. I've had a look at it and tried to emerge it on my system but it failed because it has a dependency to X11 in every cases.

It's isn't a blocking issue but that means it would "force" to build GTK4 and some gstreamer plugins with X even altough X isn't used on the system.

It's true I could apply a patch on the ebuild but I thought it wouldn't be bad to try up-streaming it since it could benefit to others.

Please let me know what you think about these changes, I left the default with both enabled so it shouldn't affect flatpak users :)