### PR TITLE
Mention more prerequisites for build

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ The following packages are required to build Kooha:
 * gstreamer
 * gstreamer-plugins-base
 * gstreamer-plugins-ugly (for MP4)
-* media-plugins/gst-plugins-lame (for MP4)
+* gstreamer-plugins-lame (for MP4)
 * gstreamer-plugins-bad (for VA encoders)
-* media-plugins/gst-plugins-vpx (for WebM)
+* gstreamer-plugins-vpx (for WebM)
 * glib2
 * gtk4
 * libadwaita

--- a/README.md
+++ b/README.md
@@ -104,7 +104,9 @@ The following packages are required to build Kooha:
 * gstreamer
 * gstreamer-plugins-base
 * gstreamer-plugins-ugly (for MP4)
+* media-plugins/gst-plugins-lame (for MP4)
 * gstreamer-plugins-bad (for VA encoders)
+* media-plugins/gst-plugins-vpx (for WebM)
 * glib2
 * gtk4
 * libadwaita


### PR DESCRIPTION
Hi,

After building from source, I noticed some profiles were missing in the list, it was because 2 gst-plugins were missing:
- gstreamer-plugins-lame: for the MP4
- gstreamer-plugins-vpx: for the WebM

If they are not installed, profiles won't be listed. Also being more exhaustive would help package maintainers in future even tho it's unofficial.

Cheers