### PR TITLE
Add feature to manually specify recording region coordinates (x, y, width, height)

### DIFF
--- a/data/resources/ui/area_selector.ui
+++ b/data/resources/ui/area_selector.ui
@@ -32,7 +32,7 @@
             </child>
             <child type="end">
               <object class="GtkButton" id="manual_button">
-                <property name="label" translatable="no">Manual Coordinates</property>
+                <property name="label" translatable="yes">Manual Coordinates</property>
                 <property name="action-name">area-selector.manual</property>
               </object>
             </child>

--- a/data/resources/ui/area_selector.ui
+++ b/data/resources/ui/area_selector.ui
@@ -31,6 +31,12 @@
               </object>
             </child>
             <child type="end">
+              <object class="GtkButton" id="manual_button">
+                <property name="label" translatable="no">Manual Coordinates</property>
+                <property name="action-name">area-selector.manual</property>
+              </object>
+            </child>
+            <child type="end">
               <object class="GtkButton">
                 <property name="tooltip-text" translatable="yes">Reset Selection</property>
                 <property name="action-name">area-selector.reset</property>

--- a/src/area_selector/mod.rs
+++ b/src/area_selector/mod.rs
@@ -108,6 +108,50 @@ mod imp {
             });
 
             klass.install_action("area-selector.manual", None, move |obj, _, _| {
+                obj.imp()
+                    .view_port
+                    .set_selection(Some(Selection::from_rect(0f32, 0f32, 100f32, 100f32)));
+
+                let dialog = adw::Dialog::builder().build();
+                let context_box = gtk::Box::new(gtk::Orientation::Vertical, 12);
+
+                // x
+                let x_adj = create_coordinate_adjustment();
+                let x_label = gtk::Label::new(Some(&"X"));
+                let x_field = gtk::SpinButton::new(Some(&x_adj), 500f64, 0u32);
+                context_box.append(&x_field);
+                context_box.append(&x_label);
+
+                // y
+                let y_adj = create_coordinate_adjustment();
+                let y_label = gtk::Label::new(Some(&"Y"));
+                let y_field = gtk::SpinButton::new(Some(&y_adj), 500f64, 0u32);
+                context_box.append(&y_field);
+                context_box.append(&y_label);
+
+                // width
+                let width_adj = create_coordinate_adjustment();
+                let width_label = gtk::Label::new(Some(&"Width"));
+                let width_field = gtk::SpinButton::new(Some(&width_adj), 500f64, 0u32);
+                context_box.append(&width_field);
+                context_box.append(&width_label);
+
+                // height
+                let height_adj = create_coordinate_adjustment();
+                let height_label = gtk::Label::new(Some(&"Height"));
+                let height_field = gtk::SpinButton::new(Some(&height_adj), 500f64, 0u32);
+                context_box.append(&height_field);
+                context_box.append(&height_label);
+
+                let margin = 16;
+                context_box.set_margin_bottom(margin);
+                context_box.set_margin_top(margin);
+                context_box.set_margin_start(margin);
+                context_box.set_margin_end(margin);
+
+                dialog.set_child(Some(&context_box));
+                dialog.present(Some(obj));
+
                 println!("CUSTOM BTUTON WORKS AAAAAAAAAAAAAA");
             });
 
@@ -183,6 +227,10 @@ mod imp {
     }
 
     impl AdwWindowImpl for AreaSelector {}
+
+    fn create_coordinate_adjustment() -> gtk::Adjustment {
+        return gtk::Adjustment::new(0f64, 0f64, 10000f64, 500f64, 500f64, 500f64);
+    }
 }
 
 glib::wrapper! {
@@ -467,7 +515,7 @@ impl AreaSelector {
 
         self.action_set_enabled("area-selector.reset", selection.is_some());
         self.action_set_enabled("area-selector.done", selection.is_some());
-        self.action_set_enabled("area-selector.manual", selection.is_some());
+        self.action_set_enabled("area-selector.manual", true);
 
         if selection.is_some() {
             imp.done_button.grab_focus();

--- a/src/area_selector/mod.rs
+++ b/src/area_selector/mod.rs
@@ -68,6 +68,8 @@ mod imp {
         #[template_child]
         pub(super) window_title: TemplateChild<adw::WindowTitle>,
         #[template_child]
+        pub(super) manual_button: TemplateChild<gtk::Button>,
+        #[template_child]
         pub(super) done_button: TemplateChild<gtk::Button>,
         #[template_child]
         pub(super) stack: TemplateChild<gtk::Stack>,
@@ -103,6 +105,10 @@ mod imp {
                 } else {
                     tracing::error!("Sent result twice");
                 }
+            });
+
+            klass.install_action("area-selector.manual", None, move |obj, _, _| {
+                println!("CUSTOM BTUTON WORKS AAAAAAAAAAAAAA");
             });
 
             klass.install_action("area-selector.done", None, move |obj, _, _| {
@@ -461,6 +467,7 @@ impl AreaSelector {
 
         self.action_set_enabled("area-selector.reset", selection.is_some());
         self.action_set_enabled("area-selector.done", selection.is_some());
+        self.action_set_enabled("area-selector.manual", selection.is_some());
 
         if selection.is_some() {
             imp.done_button.grab_focus();

--- a/src/area_selector/mod.rs
+++ b/src/area_selector/mod.rs
@@ -108,40 +108,57 @@ mod imp {
             });
 
             klass.install_action("area-selector.manual", None, move |obj, _, _| {
-                obj.imp()
-                    .view_port
-                    .set_selection(Some(Selection::from_rect(0f32, 0f32, 100f32, 100f32)));
+                let paintable_width = obj.imp().view_port.paintable_rect().unwrap().width();
+                let paintable_height = obj.imp().view_port.paintable_rect().unwrap().height();
+                let intrinstic_width = obj.imp().view_port.paintable().unwrap().intrinsic_width();
+                let mul = paintable_width / intrinstic_width as f32;
 
                 let dialog = adw::Dialog::builder().build();
                 let context_box = gtk::Box::new(gtk::Orientation::Vertical, 12);
 
                 // x
-                let x_adj = create_coordinate_adjustment();
+                let x_adj = create_coordinate_adjustment(
+                    obj.imp().view_port.selection().unwrap().left_x() / mul,
+                );
                 let x_label = gtk::Label::new(Some(&"X"));
                 let x_field = gtk::SpinButton::new(Some(&x_adj), 500f64, 0u32);
                 context_box.append(&x_field);
                 context_box.append(&x_label);
 
                 // y
-                let y_adj = create_coordinate_adjustment();
+                let y_adj = create_coordinate_adjustment(
+                    obj.imp().view_port.selection().unwrap().top_y() / mul,
+                );
                 let y_label = gtk::Label::new(Some(&"Y"));
                 let y_field = gtk::SpinButton::new(Some(&y_adj), 500f64, 0u32);
                 context_box.append(&y_field);
                 context_box.append(&y_label);
 
                 // width
-                let width_adj = create_coordinate_adjustment();
+                let width_adj = create_coordinate_adjustment(
+                    obj.imp().view_port.selection().unwrap().rect().width() / mul,
+                );
                 let width_label = gtk::Label::new(Some(&"Width"));
                 let width_field = gtk::SpinButton::new(Some(&width_adj), 500f64, 0u32);
                 context_box.append(&width_field);
                 context_box.append(&width_label);
 
                 // height
-                let height_adj = create_coordinate_adjustment();
+                let height_adj = create_coordinate_adjustment(
+                    obj.imp().view_port.selection().unwrap().rect().height() / mul,
+                );
                 let height_label = gtk::Label::new(Some(&"Height"));
                 let height_field = gtk::SpinButton::new(Some(&height_adj), 500f64, 0u32);
                 context_box.append(&height_field);
                 context_box.append(&height_label);
+
+                // cancel and apply buttons
+                let cancel_btn = gtk::Button::with_label("Cancel");
+                context_box.append(&cancel_btn);
+
+                let apply_btn = gtk::Button::with_label("Apply");
+                apply_btn.add_css_class("suggested-action");
+                context_box.append(&apply_btn);
 
                 let margin = 16;
                 context_box.set_margin_bottom(margin);
@@ -151,6 +168,32 @@ mod imp {
 
                 dialog.set_child(Some(&context_box));
                 dialog.present(Some(obj));
+
+                // button callbacks
+                cancel_btn.connect_clicked(move |_| {
+                    dialog.close();
+                });
+
+                let obj = obj.clone();
+                apply_btn.connect_clicked(move |_btn| {
+                    let min_usable_x = obj.imp().view_port.paintable_rect().unwrap().x();
+                    let min_usable_y = obj.imp().view_port.paintable_rect().unwrap().y();
+
+                    let mut x = x_adj.value() as f32 * mul;
+                    let mut y = y_adj.value() as f32 * mul;
+                    let mut width = width_adj.value() as f32 * mul;
+                    let mut height = height_adj.value() as f32 * mul;
+
+                    // bounds checks
+                    x = f32::max(x, min_usable_x);
+                    y = f32::max(y, min_usable_y);
+                    width = f32::min(width, paintable_width - x);
+                    height = f32::min(height, paintable_height - x);
+
+                    obj.imp()
+                        .view_port
+                        .set_selection(Some(Selection::from_rect(x, y, width, height)));
+                });
 
                 println!("CUSTOM BTUTON WORKS AAAAAAAAAAAAAA");
             });
@@ -228,8 +271,8 @@ mod imp {
 
     impl AdwWindowImpl for AreaSelector {}
 
-    fn create_coordinate_adjustment() -> gtk::Adjustment {
-        return gtk::Adjustment::new(0f64, 0f64, 10000f64, 500f64, 500f64, 500f64);
+    fn create_coordinate_adjustment(default: f32) -> gtk::Adjustment {
+        return gtk::Adjustment::new(default as f64, 0f64, 10000f64, 500f64, 500f64, 500f64);
     }
 }
 

--- a/src/area_selector/mod.rs
+++ b/src/area_selector/mod.rs
@@ -113,12 +113,15 @@ mod imp {
                 let intrinstic_width = obj.imp().view_port.paintable().unwrap().intrinsic_width();
                 let mul = paintable_width / intrinstic_width as f32;
 
+                let min_usable_x = obj.imp().view_port.paintable_rect().unwrap().x(); // offset
+                let min_usable_y = obj.imp().view_port.paintable_rect().unwrap().y();
+
                 let dialog = adw::Dialog::builder().build();
                 let context_box = gtk::Box::new(gtk::Orientation::Vertical, 12);
 
                 // x
                 let x_adj = create_coordinate_adjustment(
-                    obj.imp().view_port.selection().unwrap().left_x() / mul,
+                    (obj.imp().view_port.selection().unwrap().left_x() - min_usable_x) / mul,
                 );
                 let x_label = gtk::Label::new(Some(&"X"));
                 let x_field = gtk::SpinButton::new(Some(&x_adj), 500f64, 0u32);
@@ -127,7 +130,7 @@ mod imp {
 
                 // y
                 let y_adj = create_coordinate_adjustment(
-                    obj.imp().view_port.selection().unwrap().top_y() / mul,
+                    (obj.imp().view_port.selection().unwrap().top_y() - min_usable_y) / mul,
                 );
                 let y_label = gtk::Label::new(Some(&"Y"));
                 let y_field = gtk::SpinButton::new(Some(&y_adj), 500f64, 0u32);
@@ -174,28 +177,35 @@ mod imp {
                     dialog.close();
                 });
 
-                let obj = obj.clone();
+                let weak_obj = obj.downgrade();
                 apply_btn.connect_clicked(move |_btn| {
-                    let min_usable_x = obj.imp().view_port.paintable_rect().unwrap().x();
-                    let min_usable_y = obj.imp().view_port.paintable_rect().unwrap().y();
+                    let Some(obj) = weak_obj.upgrade() else {
+                        return;
+                    };
 
                     let mut x = x_adj.value() as f32 * mul;
+                    x += min_usable_x;
+
                     let mut y = y_adj.value() as f32 * mul;
+                    // there is no y offset that really /needs/ to be added, but this is to future
+                    // proof incase changes in the UI do introduce the need for an offset
+                    y += min_usable_y;
+
                     let mut width = width_adj.value() as f32 * mul;
                     let mut height = height_adj.value() as f32 * mul;
 
                     // bounds checks
                     x = f32::max(x, min_usable_x);
                     y = f32::max(y, min_usable_y);
-                    width = f32::min(width, paintable_width - x);
-                    height = f32::min(height, paintable_height - x);
+                    width = f32::min(width, paintable_width - x + min_usable_x);
+                    height = f32::min(height, paintable_height - y + min_usable_y);
 
                     obj.imp()
                         .view_port
                         .set_selection(Some(Selection::from_rect(x, y, width, height)));
-                });
 
-                println!("CUSTOM BTUTON WORKS AAAAAAAAAAAAAA");
+                    println!("x={}", x);
+                });
             });
 
             klass.install_action("area-selector.done", None, move |obj, _, _| {

--- a/src/area_selector/mod.rs
+++ b/src/area_selector/mod.rs
@@ -110,8 +110,9 @@ mod imp {
             klass.install_action("area-selector.manual", None, move |obj, _, _| {
                 let paintable_width = obj.imp().view_port.paintable_rect().unwrap().width();
                 let paintable_height = obj.imp().view_port.paintable_rect().unwrap().height();
-                let intrinstic_width = obj.imp().view_port.paintable().unwrap().intrinsic_width();
-                let mul = paintable_width / intrinstic_width as f32;
+                let intrinsic_width = obj.imp().view_port.paintable().unwrap().intrinsic_width();
+                let intrinsic_height = obj.imp().view_port.paintable().unwrap().intrinsic_height();
+                let mul = paintable_width / intrinsic_width as f32;
 
                 let min_usable_x = obj.imp().view_port.paintable_rect().unwrap().x(); // offset
                 let min_usable_y = obj.imp().view_port.paintable_rect().unwrap().y();
@@ -122,36 +123,40 @@ mod imp {
                 // x
                 let x_adj = create_coordinate_adjustment(
                     (obj.imp().view_port.selection().unwrap().left_x() - min_usable_x) / mul,
+                    intrinsic_width,
                 );
                 let x_label = gtk::Label::new(Some(&"X"));
-                let x_field = gtk::SpinButton::new(Some(&x_adj), 500f64, 0u32);
+                let x_field = gtk::SpinButton::new(Some(&x_adj), 100f64, 0u32);
                 context_box.append(&x_field);
                 context_box.append(&x_label);
 
                 // y
                 let y_adj = create_coordinate_adjustment(
                     (obj.imp().view_port.selection().unwrap().top_y() - min_usable_y) / mul,
+                    intrinsic_height,
                 );
                 let y_label = gtk::Label::new(Some(&"Y"));
-                let y_field = gtk::SpinButton::new(Some(&y_adj), 500f64, 0u32);
+                let y_field = gtk::SpinButton::new(Some(&y_adj), 100f64, 0u32);
                 context_box.append(&y_field);
                 context_box.append(&y_label);
 
                 // width
                 let width_adj = create_coordinate_adjustment(
                     obj.imp().view_port.selection().unwrap().rect().width() / mul,
+                    intrinsic_width,
                 );
                 let width_label = gtk::Label::new(Some(&"Width"));
-                let width_field = gtk::SpinButton::new(Some(&width_adj), 500f64, 0u32);
+                let width_field = gtk::SpinButton::new(Some(&width_adj), 100f64, 0u32);
                 context_box.append(&width_field);
                 context_box.append(&width_label);
 
                 // height
                 let height_adj = create_coordinate_adjustment(
                     obj.imp().view_port.selection().unwrap().rect().height() / mul,
+                    intrinsic_height,
                 );
                 let height_label = gtk::Label::new(Some(&"Height"));
-                let height_field = gtk::SpinButton::new(Some(&height_adj), 500f64, 0u32);
+                let height_field = gtk::SpinButton::new(Some(&height_adj), 100f64, 0u32);
                 context_box.append(&height_field);
                 context_box.append(&height_label);
 
@@ -187,8 +192,6 @@ mod imp {
                     x += min_usable_x;
 
                     let mut y = y_adj.value() as f32 * mul;
-                    // there is no y offset that really /needs/ to be added, but this is to future
-                    // proof incase changes in the UI do introduce the need for an offset
                     y += min_usable_y;
 
                     let mut width = width_adj.value() as f32 * mul;
@@ -203,8 +206,6 @@ mod imp {
                     obj.imp()
                         .view_port
                         .set_selection(Some(Selection::from_rect(x, y, width, height)));
-
-                    println!("x={}", x);
                 });
             });
 
@@ -281,8 +282,8 @@ mod imp {
 
     impl AdwWindowImpl for AreaSelector {}
 
-    fn create_coordinate_adjustment(default: f32) -> gtk::Adjustment {
-        return gtk::Adjustment::new(default as f64, 0f64, 10000f64, 500f64, 500f64, 500f64);
+    fn create_coordinate_adjustment(default: f32, upper: i32) -> gtk::Adjustment {
+        return gtk::Adjustment::new(default as f64, 0f64, upper as f64, 100f64, 100f64, 0f64);
     }
 }
 

--- a/src/area_selector/view_port.rs
+++ b/src/area_selector/view_port.rs
@@ -90,7 +90,7 @@ impl fmt::Debug for Selection {
 }
 
 impl Selection {
-    fn from_rect(x: f32, y: f32, width: f32, height: f32) -> Self {
+    pub fn from_rect(x: f32, y: f32, width: f32, height: f32) -> Self {
         Self {
             start_x: x,
             start_y: y,


### PR DESCRIPTION
I used Kooha to record some GIFs, and wanted to manually specify region coordinates for consistent recordings

The feature implementation is very simple, however I feel I should point out that I made `Selection::from_rect()` public to make it easy to update the existing selection.