### PR TITLE
fix(pipeline): scale odd-sized streams to even resolution

### DIFF
--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -67,7 +67,9 @@ impl PipelineBuilder {
     ///                        |             |
     ///                        v             v
     /// pipewiresrc-bin -> videoscale -> videocrop -> queue -> |
-    ///                                                        | -> profile.attach -> filesink
+    ///         |                                              | -> profile.attach -> filesink
+    ///         | (If combined stream size is odd or unknown)  |
+    ///         +---------> videoscale --------> queue --------+
     ///                               pulsesrc-bin -> queue -> |
     pub fn build(&self) -> Result<gst::Pipeline> {
         tracing::debug!(
@@ -114,8 +116,28 @@ impl PipelineBuilder {
             videosrc_bin.link(&videoscale)?;
             videoscale.link_filtered(&videocrop, &videoscale_caps)?;
             videocrop.link(&videoenc_queue)?;
-        } else {
+        } else if streams_total_size(&self.streams)
+            .is_some_and(|(width, height)| width % 2 == 0 && height % 2 == 0)
+        {
             videosrc_bin.link(&videoenc_queue)?;
+        } else {
+            // Some encoders (e.g., x264enc) require even resolution, but the
+            // streams (e.g., a window capture) may have odd dimensions, and
+            // their size may be unknown or differ from the portal metadata
+            // (e.g., due to rotation), so restrict the caps to even values and
+            // let videoscale follow the negotiated size.
+            let videoscale = gst::ElementFactory::make("videoscale").build()?;
+            pipeline.add(&videoscale)?;
+
+            // The maximum must be well below `i32::MAX`, as larger values
+            // overflow videoscale's internal aspect-ratio arithmetic.
+            let videoscale_caps = gst::Caps::builder("video/x-raw")
+                .field("width", gst::IntRange::with_step(2, 65536, 2))
+                .field("height", gst::IntRange::with_step(2, 65536, 2))
+                .build();
+
+            videosrc_bin.link(&videoscale)?;
+            videoscale.link_filtered(&videoenc_queue, &videoscale_caps)?;
         }
 
         let audioenc_queue = if self.record_desktop_audio || self.record_microphone {
@@ -414,6 +436,25 @@ fn make_audiosrc_bin<'a>(
     Ok(bin)
 }
 
+/// Computes the total size of the streams when combined in the pipeline.
+///
+/// Multiple streams are stacked horizontally, so the total width is the sum
+/// of the stream widths and the height is the maximum of the stream heights.
+///
+/// Returns `None` if the size of a stream is unknown.
+fn streams_total_size(streams: &[Stream]) -> Option<(i32, i32)> {
+    let mut total_width = 0;
+    let mut max_height = 0;
+
+    for stream in streams {
+        let (width, height) = stream.size()?;
+        total_width += width;
+        max_height = max_height.max(height);
+    }
+
+    Some((total_width, max_height))
+}
+
 fn round_to_even(number: i32) -> i32 {
     number / 2 * 2
 }
@@ -425,6 +466,8 @@ fn round_to_even_f32(number: f32) -> i32 {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    use gtk::glib::{self, prelude::*};
 
     macro_rules! assert_even {
         ($number:expr) => {
@@ -460,5 +503,45 @@ mod test {
     fn float_round_to_even_f32() {
         assert_even!(round_to_even_f32(5.3));
         assert_even!(round_to_even_f32(2.9));
+    }
+
+    fn stream_with_size(size: Option<(i32, i32)>) -> Stream {
+        let variant_str = match size {
+            Some((width, height)) => {
+                format!("(uint32 63, {{'size': <({width}, {height})>}})")
+            }
+            None => "(uint32 63, {})".to_string(),
+        };
+        glib::Variant::parse(Some(&Stream::static_variant_type()), &variant_str)
+            .unwrap()
+            .get::<Stream>()
+            .unwrap()
+    }
+
+    #[test]
+    fn streams_total_size_single() {
+        let streams = [stream_with_size(Some((1920, 1080)))];
+        assert_eq!(streams_total_size(&streams), Some((1920, 1080)));
+    }
+
+    #[test]
+    fn streams_total_size_single_odd() {
+        let streams = [stream_with_size(Some((1365, 717)))];
+        assert_eq!(streams_total_size(&streams), Some((1365, 717)));
+    }
+
+    #[test]
+    fn streams_total_size_multiple_stacked_horizontally() {
+        let streams = [
+            stream_with_size(Some((1920, 1080))),
+            stream_with_size(Some((2560, 1440))),
+        ];
+        assert_eq!(streams_total_size(&streams), Some((4480, 1440)));
+    }
+
+    #[test]
+    fn streams_total_size_unknown() {
+        let streams = [stream_with_size(Some((1920, 1080))), stream_with_size(None)];
+        assert_eq!(streams_total_size(&streams), None);
     }
 }


### PR DESCRIPTION
Fixes #357

## Problem

Recording with the MP4 or Matroska profile fails with `Can not initialize x264 encoder` when the captured stream has an odd width or height — typical for window captures. The pipeline log shows the underlying cause:

```
x264enc gstx264enc.c:1331: width not divisible by 2 (1365x717)
gstx264enc.c(1965): gst_x264_enc_init_encoder (): ... Can not initialize x264 encoder.
```

x264 requires even dimensions, but the even rounding previously only existed in the select-area path (`videoscale` + `videocrop`). Captures without a selection linked the stream directly to the encoder queue.

## Fix

When there is no area selection and the combined stream size is odd **or unknown**, insert a `videoscale` restricted to even stepped caps (`width/height = [2, 65536, 2]`). This way `videoscale` follows the actually negotiated size (after `videoflip`/`compositor`) and rounds down to even, instead of relying on portal metadata that may be missing or disagree with the buffers. Streams known to be even are linked directly, as before.

The combined size of multiple streams is computed as the sum of widths and the maximum height, matching how they are stacked horizontally by the compositor.

The stepped range maximum is 65536 rather than `i32::MAX` because larger values overflow videoscale's internal aspect-ratio arithmetic, producing empty (`[0, 0]`) caps during negotiation.

## Verification

- Unit tests for the combined-size computation (single, odd, multiple, unknown size).
- `gst-launch` check: `1365x717` input with the stepped caps negotiates to `1364x716`; even input passes through unscaled.
- Smoke test: recorded an odd-sized window to MP4 successfully.
- `cargo fmt --check` and `cargo clippy -- -D warnings` are clean.
- `cargo test` passes except for 5 failures (`i18n`, `profile`, `settings` tests) that also fail on unmodified `main` in this environment (missing installed gresource, should-panic behavior).
